### PR TITLE
Fix deprecated calls

### DIFF
--- a/Casks/wch-ch34x-usb-serial-driver.rb
+++ b/Casks/wch-ch34x-usb-serial-driver.rb
@@ -6,8 +6,6 @@ cask 'wch-ch34x-usb-serial-driver' do
   name 'WCH USB serial driver for CH340/CH341 (unofficial release)'
   homepage 'https://github.com/adrianmihalko/ch340g-ch34g-ch34x-mac-os-x-driver'
 
-  license :gratis
-
   pkg 'CH34x_Install_V1.4.pkg'
 
   uninstall pkgutil: 'com.wch.usbserial',
@@ -17,7 +15,7 @@ cask 'wch-ch34x-usb-serial-driver' do
                        '/Library/Extensions/usbserial.kext',
                      ]
 
-  caveats <<-EOS.undent
+  caveats <<~EOS
     This driver was sourced from the OEM website. Discussion:
     https://github.com/adrianmihalko/ch340g-ch34g-ch34x-mac-os-x-driver
   EOS


### PR DESCRIPTION
Installing this cask before this PR change results in every cask cli command outputting the following error log:

```console
Warning: Calling Hbc::DSL#license is deprecated!
There is no replacement.
/usr/local/Homebrew/Library/Taps/mengbo/homebrew-ch340g-ch34g-ch34x-mac-os-x-driver/Casks/wch-ch34x-usb-serial-driver.rb:9:in `block in load'
Please report this to the mengbo/ch340g-ch34g-ch34x-mac-os-x-driver tap!

Error: Calling <<-EOS.undent is disabled!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/mengbo/homebrew-ch340g-ch34g-ch34x-mac-os-x-driver/Casks/wch-ch34x-usb-serial-driver.rb:23:in `block in load'
Please report this to the mengbo/ch340g-ch34g-ch34x-mac-os-x-driver tap!
Or, even better, submit a PR to fix it!
Follow the instructions here:
  https://github.com/caskroom/homebrew-cask#reporting-bugs
/usr/local/Homebrew/Library/Homebrew/utils.rb:113:in `odeprecated'
/usr/local/Homebrew/Library/Homebrew/utils.rb:121:in `odisabled'
/usr/local/Homebrew/Library/Homebrew/compat/extend/string.rb:3:in `undent'
/usr/local/Homebrew/Library/Taps/mengbo/homebrew-ch340g-ch34g-ch34x-mac-os-x-driver/Casks/wch-ch34x-usb-serial-driver.rb:23:in `block in load'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cask.rb:23:in `instance_eval'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cask.rb:23:in `initialize'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cask_loader.rb:31:in `new'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cask_loader.rb:31:in `cask'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cask_loader.rb:67:in `cask'
/usr/local/Homebrew/Library/Homebrew/compat/hbc/cask_loader.rb:10:in `cask'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cask_loader.rb:113:in `cask'
/usr/local/Homebrew/Library/Taps/mengbo/homebrew-ch340g-ch34g-ch34x-mac-os-x-driver/Casks/wch-ch34x-usb-serial-driver.rb:1:in `load'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cask_loader.rb:57:in `instance_eval'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cask_loader.rb:57:in `load'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cask_loader.rb:170:in `load'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/scopes.rb:39:in `block in installed'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/scopes.rb:31:in `map'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/scopes.rb:31:in `installed'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli/list.rb:40:in `list_installed'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli/list.rb:14:in `run'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli/abstract_command.rb:35:in `run'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli.rb:98:in `run_command'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli.rb:168:in `run'
/usr/local/Homebrew/Library/Homebrew/cask/lib/hbc/cli.rb:132:in `run'
/usr/local/Homebrew/Library/Homebrew/cmd/cask.rb:8:in `cask'
/usr/local/Homebrew/Library/Homebrew/brew.rb:101:in `<main>'
```